### PR TITLE
Modify filename in module info in order to allow proper loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ As for the `main_info.php` I need to adjust the class name from `acp_newspage_in
 		function module()
 		{
 			return array(
-				'filename'	=> 'main_module',
+				'filename'	=> 'phpbb_ext_nickvergessen_newspage_acp_main_module',
 				'title'		=> 'ACP_NEWSPAGE_TITLE',
 				'version'	=> '1.0.1',
 				'modes'		=> array(


### PR DESCRIPTION
The filename attribute in the module info file needs to be changed to
reflect the module file's class name in order to be able to find that
module with the extension finder, and add it in the ACP.
